### PR TITLE
Escape windows backslash in generated metro config

### DIFF
--- a/src/getMetroConfig.js
+++ b/src/getMetroConfig.js
@@ -51,7 +51,7 @@ module.exports = symlinkedDependencies => {
     const getBlacklistRE = symlinkedDependenciesPaths.map(mapPath).join(',\n')
 
     const getProjectRoots = symlinkedDependenciesPaths
-        .map(path => `    path.resolve('${path}')`)
+        .map(path => `    path.resolve('${path.replace(/\\/g, '\\\\')}')`)
         .join(',\n')
 
     return dedent`


### PR DESCRIPTION
Fixes https://github.com/MrLoh/metro-with-symlinks/issues/2
